### PR TITLE
interactive fuzzy search (only substring comparison for now)

### DIFF
--- a/exo/exo-icon-view.c
+++ b/exo/exo-icon-view.c
@@ -9248,7 +9248,7 @@ exo_icon_view_search_equal_func (GtkTreeModel *model,
       case_normalized_key = g_utf8_casefold (normalized_key, -1);
 
       /* compare the casefolded strings */
-      if (strncmp (case_normalized_key, case_normalized_string, strlen (case_normalized_key)) == 0)
+      if (strnstr (case_normalized_string, case_normalized_key, strlen (case_normalized_string)) != NULL)
         retval = FALSE;
     }
 


### PR DESCRIPTION
Convert exact matching for interactive search to a more relaxed substring match. Extra functionality for exo-icon-view especially in Thunar. Can be extended to a complete fuzzy search if the idea is accepted. Can be made optional via a setting variable.